### PR TITLE
Fix compilation with Qt6

### DIFF
--- a/QsLogDestFile.cpp
+++ b/QsLogDestFile.cpp
@@ -24,7 +24,9 @@
 // OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "QsLogDestFile.h"
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include <QTextCodec>
+#endif
 #include <QDateTime>
 #include <QtGlobal>
 #include <iostream>
@@ -132,7 +134,9 @@ QsLogging::FileDestination::FileDestination(const QString& filePath, RotationStr
     if (!mFile.open(QFile::WriteOnly | QFile::Text | mRotationStrategy->recommendedOpenModeFlag()))
         std::cerr << "QsLog: could not open log file " << qPrintable(filePath);
     mOutputStream.setDevice(&mFile);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     mOutputStream.setCodec(QTextCodec::codecForName("UTF-8"));
+#endif
 
     mRotationStrategy->setInitialInfo(mFile);
 }


### PR DESCRIPTION
Setting the output codec to UTF-8 is no longer necessary as the default in Qt6 is already UTF-8.